### PR TITLE
Simplify hashing infrastructure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,9 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17 -Wall -Wextra -Wno-noexcept-t
 find_package(OpenMP)
 if (OpenMP_FOUND)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
+    if (OpenMP_CXX_INCLUDE_DIR)
+        include_directories("${OpenMP_CXX_INCLUDE_DIR}")
+    endif()
 endif()
 
 find_package(HDF5)

--- a/bench/bench.cpp
+++ b/bench/bench.cpp
@@ -14,10 +14,46 @@
 #include <sstream>
 #include <iostream>
 #include <chrono>
+#include <omp.h>
 
 const unsigned int MB = 1024*1024;
 
 std::vector<std::vector<float>> read_glove(const std::string& filename);
+
+void bench_api_simhash(
+    const std::vector<std::vector<float>> & dataset
+) {
+    auto bencher = ankerl::nanobench::Bench()
+        .title("Simhash computations")
+        .minEpochIterations(100)
+        .batch(dataset.size())
+        .timeUnit(std::chrono::nanoseconds(1), "ns");
+
+    auto dimensions = dataset[0].size(); 
+    puffinn::Dataset<puffinn::UnitVectorFormat> dat(dimensions);
+    for (auto v : dataset) { dat.insert(v); }
+    size_t n = dataset.size();
+
+    auto source = puffinn::IndependentHashArgs<puffinn::SimHash>().build(
+        dat.get_description(), 1, 24
+    );
+
+    auto hash_fn = source->sample();
+
+    bencher.run("old API", [&] {
+        for (size_t i=0; i<n; i++) {
+            auto state = source->reset(dat[i], false);
+            ankerl::nanobench::doNotOptimizeAway((*hash_fn)(state.get()));
+        }
+    });
+
+    std::vector<uint32_t> hashes;
+    bencher.run("new API", [&] {
+        for (size_t i=0; i<n; i++) {
+            source->hash_repetitions(dat[i], hashes);
+        }
+    });
+}
 
 template<typename THash, typename THashSourceArgs>
 void do_build_index(ankerl::nanobench::Bench * bencher, const char * name, const std::vector<std::vector<float>> & dataset, double index_memory) {
@@ -29,7 +65,7 @@ void do_build_index(ankerl::nanobench::Bench * bencher, const char * name, const
             THashSourceArgs()
         );
         for (auto v : dataset) { index.insert(v); }
-        index.rebuild();
+        index.rebuild(false);
     });
 }
 
@@ -40,24 +76,41 @@ void bench_index_build(const std::vector<std::vector<float>> & dataset) {
     // To benchmark the index build time we have to start from a new
     // index at each measurement iteration, otherwise the index is already populated
     // and no rebuild is triggered.
-    auto bencher = ankerl::nanobench::Bench()
-        .title("Index building");
-    auto index_memory = 100*MB;
-    // auto index_memory = 0.8*MB;
-
-    bencher.run("index_insert_data", [&] {
-        puffinn::Index<puffinn::CosineSimilarity, puffinn::SimHash> index(
-            dimensions,
-            index_memory
-        );
-        for (auto v : dataset) { index.insert(v); }
-    });
+    auto bencher = ankerl::nanobench::Bench();
+    // auto index_memory = 100*MB;
     
     // memory is set so that we have 600 tables
-    do_build_index<puffinn::SimHash, puffinn::IndependentHashArgs<puffinn::SimHash>>(&bencher, "SimHash independent", dataset, 537*MB); // 74 MB
-    do_build_index<puffinn::SimHash, puffinn::TensoredHashArgs<puffinn::SimHash>>(&bencher, "SimHash tensored", dataset, 534*MB); // 70.6 MB
-    do_build_index<puffinn::FHTCrossPolytopeHash, puffinn::IndependentHashArgs<puffinn::FHTCrossPolytopeHash>>(&bencher, "FHT CrossPolytope independent", dataset, 534.5*MB); // 71.2 MB
-    do_build_index<puffinn::FHTCrossPolytopeHash, puffinn::TensoredHashArgs<puffinn::FHTCrossPolytopeHash>>(&bencher, "FHT CrossPolytope tensored", dataset, 534*MB); // 70.5 MB
+    bencher.title("Simhash independent");
+    omp_set_num_threads(1);
+    do_build_index<puffinn::SimHash, puffinn::IndependentHashArgs<puffinn::SimHash>>(&bencher, "1 thread", dataset, 537*MB); // 74 MB
+    omp_set_num_threads(2);
+    do_build_index<puffinn::SimHash, puffinn::IndependentHashArgs<puffinn::SimHash>>(&bencher, "2 threads", dataset, 537*MB); // 74 MB
+    omp_set_num_threads(4);
+    do_build_index<puffinn::SimHash, puffinn::IndependentHashArgs<puffinn::SimHash>>(&bencher, "4 threads", dataset, 537*MB); // 74 MB
+    omp_set_num_threads(8);
+    do_build_index<puffinn::SimHash, puffinn::IndependentHashArgs<puffinn::SimHash>>(&bencher, "8 threads", dataset, 537*MB); // 74 MB
+    omp_set_num_threads(16);
+    do_build_index<puffinn::SimHash, puffinn::IndependentHashArgs<puffinn::SimHash>>(&bencher, "16 threads", dataset, 537*MB); // 74 MB
+    omp_set_num_threads(32);
+    do_build_index<puffinn::SimHash, puffinn::IndependentHashArgs<puffinn::SimHash>>(&bencher, "32 threads", dataset, 537*MB); // 74 MB
+
+    bencher.title("Simhash tensored");
+    omp_set_num_threads(1);
+    do_build_index<puffinn::SimHash, puffinn::TensoredHashArgs<puffinn::SimHash>>(&bencher, "1 thread", dataset, 537*MB); // 74 MB
+    omp_set_num_threads(2);
+    do_build_index<puffinn::SimHash, puffinn::TensoredHashArgs<puffinn::SimHash>>(&bencher, "2 threads", dataset, 537*MB); // 74 MB
+    omp_set_num_threads(4);
+    do_build_index<puffinn::SimHash, puffinn::TensoredHashArgs<puffinn::SimHash>>(&bencher, "4 threads", dataset, 537*MB); // 74 MB
+    omp_set_num_threads(8);
+    do_build_index<puffinn::SimHash, puffinn::TensoredHashArgs<puffinn::SimHash>>(&bencher, "8 threads", dataset, 537*MB); // 74 MB
+    omp_set_num_threads(16);
+    do_build_index<puffinn::SimHash, puffinn::TensoredHashArgs<puffinn::SimHash>>(&bencher, "16 threads", dataset, 537*MB); // 74 MB
+    omp_set_num_threads(32);
+    do_build_index<puffinn::SimHash, puffinn::TensoredHashArgs<puffinn::SimHash>>(&bencher, "32 threads", dataset, 537*MB); // 74 MB
+
+    // do_build_index<puffinn::SimHash, puffinn::TensoredHashArgs<puffinn::SimHash>>(&bencher, "SimHash tensored", dataset, 534*MB); // 70.6 MB
+    // do_build_index<puffinn::FHTCrossPolytopeHash, puffinn::IndependentHashArgs<puffinn::FHTCrossPolytopeHash>>(&bencher, "FHT CrossPolytope independent", dataset, 534.5*MB); // 71.2 MB
+    // do_build_index<puffinn::FHTCrossPolytopeHash, puffinn::TensoredHashArgs<puffinn::FHTCrossPolytopeHash>>(&bencher, "FHT CrossPolytope tensored", dataset, 534*MB); // 70.5 MB
 }
 
 void bench_query(const std::vector<std::vector<float>> & dataset) {
@@ -163,6 +216,7 @@ int main(int argc, char ** argv) {
     }
     auto dataset = read_glove(argv[1]);
 
+    // bench_api_simhash(dataset);
     // bench_query(dataset);
     bench_index_build(dataset);
     // bench_hash(dataset);

--- a/include/puffinn/collection.hpp
+++ b/include/puffinn/collection.hpp
@@ -291,7 +291,7 @@ namespace puffinn {
                 // Construct the prefixmaps.
                 lsh_maps.reserve(num_tables);
                 for (unsigned int repetition=0; repetition < num_tables; repetition++) {
-                    lsh_maps.emplace_back(this->hash_source->sample(), MAX_HASHBITS);
+                    lsh_maps.emplace_back(MAX_HASHBITS);
                 }
             }
 
@@ -304,25 +304,12 @@ namespace puffinn {
             // Hash a vector in all the different ways needed.
             std::vector<LshDatatype> hash_values;
             for (size_t idx=last_rebuild; idx < dataset.get_size(); idx++) {
-                // auto hash_state = this->hash_source->reset(dataset[idx], true);
                 // Write the hash values in the vector
                 this->hash_source->hash_repetitions(dataset[idx], hash_values);
                 // Copy the hash values in the appropriate prefix maps
                 for (size_t map_idx = 0; map_idx < lsh_maps.size(); map_idx++) {
-                    lsh_maps[map_idx].insert_direct(idx, hash_values[map_idx]);
+                    lsh_maps[map_idx].insert(idx, hash_values[map_idx]);
                 }
-
-                // Only parallelize if this step is computationally expensive.
-                // if (hash_source->precomputed_hashes()) {
-                //     for (auto& map : lsh_maps) {
-                //         map.insert(idx, hash_state.get());
-                //     }
-                // } else {
-                //     #pragma omp parallel for
-                //     for (size_t map_idx = 0; map_idx < lsh_maps.size(); map_idx++) {
-                //         lsh_maps[map_idx].insert(idx, hash_state.get());
-                //     }
-                // }
             }
             g_performance_metrics.store_time(Computation::IndexHashing);
 
@@ -880,10 +867,10 @@ namespace puffinn {
 
             MaxBuffer maxbuffer(k);
             g_performance_metrics.start_timer(Computation::Hashing);
-            auto hash_state = hash_source->reset(query, false);
             std::vector<LshDatatype> query_hashes;
             hash_source->hash_repetitions(query, query_hashes);
             g_performance_metrics.store_time(Computation::Hashing);
+
             g_performance_metrics.start_timer(Computation::Sketching);
             auto sketches = filterer.reset(query);
             g_performance_metrics.store_time(Computation::Sketching);
@@ -905,11 +892,9 @@ namespace puffinn {
                         recall,
                         sketches,
                         query_hashes);
-                        // hash_state.get());
                     break;
                 default:
                     search_maps(query, maxbuffer, recall, sketches, query_hashes);
-                    // search_maps(query, maxbuffer, recall, sketches, hash_state.get());
             }
             g_performance_metrics.store_time(Computation::Search);
 
@@ -946,7 +931,6 @@ namespace puffinn {
             SearchBuffers(
                 const std::vector<PrefixMap<THash>>& maps,
                 QuerySketches sketches,
-                // HashSourceState* hash_state
                 std::vector<LshDatatype> & hashes
             )
               : sketches(sketches)
@@ -962,8 +946,6 @@ namespace puffinn {
                 for (size_t i = 0; i < maps.size(); i++) {
                     query_objects.push_back(maps[i].create_query(hashes[i]));
                 }
-                // std::transform(maps.begin(), maps.end(), std::back_inserter(query_objects),
-                //     [hash_state](auto& map) { return map.create_query(hash_state); });
 
                 g_performance_metrics.store_time(Computation::SearchInit);
             }
@@ -995,9 +977,7 @@ namespace puffinn {
             float recall,
             QuerySketches sketches,
             std::vector<LshDatatype> & query_hashes
-            // HashSourceState* hash_state
         ) const {
-            // SearchBuffers buffers(lsh_maps, sketches, hash_state);
             SearchBuffers buffers(lsh_maps, sketches, query_hashes);
             for (uint_fast8_t depth=MAX_HASHBITS; depth > 0; depth--) {
                 buffers.fill_ranges(lsh_maps);
@@ -1042,9 +1022,7 @@ namespace puffinn {
             float recall,
             QuerySketches sketches,
             std::vector<LshDatatype> & query_hashes
-            // HashSourceState* hash_state
         ) const {
-            // SearchBuffers buffers(lsh_maps, sketches, hash_state);
             SearchBuffers buffers(lsh_maps, sketches, query_hashes);
             for (uint_fast8_t depth=MAX_HASHBITS; depth > 0; depth--) {
                 buffers.fill_ranges(lsh_maps);
@@ -1095,11 +1073,9 @@ namespace puffinn {
             float recall,
             QuerySketches sketches,
             std::vector<LshDatatype> & query_hashes
-            // HashSourceState* hash_state
         ) const {
             const size_t FILTER_BUFFER_SIZE = 128;
 
-            // SearchBuffers buffers(lsh_maps, sketches, hash_state);
             SearchBuffers buffers(lsh_maps, sketches, query_hashes);
             // Buffer for values passing filtering and should have distances computed.
             // 8*RING_SIZE is necessary additional space as that is the maximum that can be added

--- a/include/puffinn/hash_source/hash_source.hpp
+++ b/include/puffinn/hash_source/hash_source.hpp
@@ -28,6 +28,13 @@ namespace puffinn {
         // Sample a random hash function from this source.
         virtual std::unique_ptr<Hash> sample() = 0;
 
+        // Compute the LSH values for all tables supported by this pool for the given input vector.
+        // Writes the results to the given output array, which can be reused
+        virtual void hash_repetitions(
+            typename T::Sim::Format::Type * input,
+            std::vector<LshDatatype> & output
+        ) const = 0;
+
         // Initialize the state necessary to compute the hashes of the given vector.
         virtual std::unique_ptr<HashSourceState> reset(
             typename T::Sim::Format::Type* vec,

--- a/include/puffinn/hash_source/independent.hpp
+++ b/include/puffinn/hash_source/independent.hpp
@@ -3,6 +3,8 @@
 #include "puffinn/dataset.hpp"
 #include "puffinn/hash_source/hash_source.hpp"
 
+#include <iostream>
+
 #include <memory>
 #include <vector>
 
@@ -57,6 +59,7 @@ namespace puffinn {
             for (size_t i=0; i < funcs_len; i++) {
                 hash_functions.push_back(typename T::Function(in));
             }
+            in.read(reinterpret_cast<char*>(&num_hashers), sizeof(unsigned int));
             in.read(reinterpret_cast<char*>(&functions_per_hasher), sizeof(unsigned int));
             in.read(reinterpret_cast<char*>(&bits_per_function), sizeof(uint_fast8_t));
             in.read(reinterpret_cast<char*>(&next_function), sizeof(unsigned int));
@@ -70,6 +73,7 @@ namespace puffinn {
             for (auto& h : hash_functions) {
                 h.serialize(out);
             }
+            out.write(reinterpret_cast<const char*>(&num_hashers), sizeof(unsigned int));
             out.write(reinterpret_cast<const char*>(&functions_per_hasher), sizeof(unsigned int));
             out.write(reinterpret_cast<const char*>(&bits_per_function), sizeof(uint_fast8_t));
             out.write(reinterpret_cast<const char*>(&next_function), sizeof(unsigned int));
@@ -85,10 +89,11 @@ namespace puffinn {
             output.clear();
             // Iterate through all the functions, accumulating bits
             for (size_t rep = 0; rep < num_hashers; rep++) {
+                size_t offset = rep * functions_per_hasher;
                 LshDatatype res = 0;
                 for (unsigned int i=0; i < functions_per_hasher; i++) {
                     res <<= bits_per_function;
-                    res |= hash_functions[rep+i](input);
+                    res |= hash_functions[offset+i](input);
                 }
                 res >>= bits_to_cut;
                 output.push_back(res);
@@ -104,7 +109,7 @@ namespace puffinn {
                 res <<= bits_per_function;
                 res |= hash_functions[first_hash+i](hashed_vec);
             }
-            return (res >> bits_to_cut);
+            return res >> bits_to_cut;
         }
 
         std::unique_ptr<HashSourceState> reset(

--- a/include/puffinn/hash_source/independent.hpp
+++ b/include/puffinn/hash_source/independent.hpp
@@ -86,7 +86,7 @@ namespace puffinn {
             typename T::Sim::Format::Type * input,
             std::vector<LshDatatype> & output
         ) const {
-            output.clear();
+            output.resize(num_hashers);
             // Iterate through all the functions, accumulating bits
             for (size_t rep = 0; rep < num_hashers; rep++) {
                 size_t offset = rep * functions_per_hasher;
@@ -96,7 +96,7 @@ namespace puffinn {
                     res |= hash_functions[offset+i](input);
                 }
                 res >>= bits_to_cut;
-                output.push_back(res);
+                output[rep] = res;
             }
         }
 

--- a/include/puffinn/hash_source/pool.hpp
+++ b/include/puffinn/hash_source/pool.hpp
@@ -28,6 +28,7 @@ namespace puffinn {
         uint_fast8_t bits_per_function;
         unsigned int bits_per_hasher;
         unsigned int current_sampling_rep = 0;
+        unsigned int bits_to_cut;
 
     public:
         HashPool(
@@ -60,6 +61,8 @@ namespace puffinn {
                 }
                 indices.push_back(rep_indices);
             }
+
+            bits_to_cut = bits_per_function * indices[0].size() - bits_per_hasher;
 
             // TODO: remove this is needed just to reset the state when testing, so
             // that if we call sample many times, we get the same sequences of indices we just constructed 
@@ -142,7 +145,7 @@ namespace puffinn {
                     res <<= bits_per_function;
                     res |= pool[idx];
                 }
-                output.push_back(res);
+                output.push_back(res >> bits_to_cut);
             }
         }
 

--- a/include/puffinn/hash_source/pool.hpp
+++ b/include/puffinn/hash_source/pool.hpp
@@ -134,6 +134,16 @@ namespace puffinn {
             for (size_t i = 0; i < hash_functions.size(); i++) {
                 pool.push_back(hash_functions[i](input));
             }
+
+            for (size_t rep = 0; rep < num_tables; rep++) {
+                // Concatenate the hashes
+                uint32_t res = 0;
+                for (auto idx : indices[rep]) {
+                    res <<= bits_per_function;
+                    res |= pool[idx];
+                }
+                output.push_back(res);
+            }
         }
 
         // Recompute hashes for a new vector.

--- a/include/puffinn/prefixmap.hpp
+++ b/include/puffinn/prefixmap.hpp
@@ -77,6 +77,7 @@ namespace puffinn {
 
         // Length of the hash values used.
         unsigned int hash_length;
+        // TODO: remove this, the responsibility of hashing should go to the collection: the prefixmap should only be responsible of arranging data
         std::unique_ptr<Hash> hash_function;
 
         // index of the first value with each prefix.
@@ -149,6 +150,11 @@ namespace puffinn {
         // Expects that the hash source was last reset with that vector.
         void insert(uint32_t idx, HashSourceState* hash_state) {
             rebuilding_data.push_back({ idx, (*hash_function)(hash_state) });
+        }
+
+        // Insert a hash value computed elsewhere
+        void insert_direct(uint32_t idx, LshDatatype hash_value) {
+            rebuilding_data.push_back({ idx, hash_value });
         }
 
         // Reserve the correct amount of memory before inserting.
@@ -236,10 +242,8 @@ namespace puffinn {
         }
 
         // Construct a query object to search for the nearest neighbors of the given vector.
-        PrefixMapQuery create_query(HashSourceState* hash_state) const {
-            g_performance_metrics.start_timer(Computation::Hashing);
-            auto hash = (*hash_function)(hash_state);
-            g_performance_metrics.store_time(Computation::Hashing);
+        PrefixMapQuery create_query(LshDatatype hash) const {
+        // PrefixMapQuery create_query(HashSourceState* hash_state) const {
             g_performance_metrics.start_timer(Computation::CreateQuery);
             auto prefix = hash >> (hash_length-PREFIX_INDEX_BITS);
             PrefixMapQuery res(

--- a/include/puffinn/typedefs.hpp
+++ b/include/puffinn/typedefs.hpp
@@ -17,7 +17,9 @@ namespace puffinn {
     // truncated to `LshDatatype` when push_back is called on `rebuilding_data`.
     using LshDatatype = uint32_t;
 
-    std::default_random_engine generator(std::chrono::system_clock::now().time_since_epoch().count());
+    // std::default_random_engine generator(std::chrono::system_clock::now().time_since_epoch().count());
+    // for reproducibility, fix the seed of the random number generator
+    std::default_random_engine generator(1234);
 
     // Retrieve the default random engine, seeded once by the system clock.
     std::default_random_engine& get_default_random_generator() {

--- a/include/puffinn/typedefs.hpp
+++ b/include/puffinn/typedefs.hpp
@@ -12,6 +12,9 @@ namespace puffinn {
     // Number of bits used in hashes.
     const static unsigned int MAX_HASHBITS = 24;
     // The hash_pool concatenates hashes into a type twice as large to avoid overflow errors.
+    // TODO: Check how to avoid this "twice as large": using 64 bits to store 24-bits hash values.
+    // To me it seems that when inserting into a prefix-map, 64 bits are automatically 
+    // truncated to `LshDatatype` when push_back is called on `rebuilding_data`.
     using LshDatatype = uint32_t;
 
     std::default_random_engine generator(std::chrono::system_clock::now().time_since_epoch().count());

--- a/include/puffinn/typedefs.hpp
+++ b/include/puffinn/typedefs.hpp
@@ -21,6 +21,10 @@ namespace puffinn {
     // for reproducibility, fix the seed of the random number generator
     std::default_random_engine generator(1234);
 
+    void reset_random_generator() {
+        generator = std::default_random_engine(1234);
+    }
+
     // Retrieve the default random engine, seeded once by the system clock.
     std::default_random_engine& get_default_random_generator() {
         return generator;

--- a/join-experiments/glove-join.cpp
+++ b/join-experiments/glove-join.cpp
@@ -101,8 +101,8 @@ int main(int argc, char* argv[]) {
     puffinn::Index<puffinn::CosineSimilarity, puffinn::SimHash> index(
         dimensions,
         space_usage,
-        puffinn::TensoredHashArgs<puffinn::SimHash>()
-        // puffinn::IndependentHashArgs<puffinn::SimHash>()
+        // puffinn::TensoredHashArgs<puffinn::SimHash>()
+        puffinn::IndependentHashArgs<puffinn::SimHash>()
     );
     // Insert each vector into the index.
     for (auto word : dataset.words) { index.insert(dataset.vectors[word]); }

--- a/test/include/collection_test.hpp
+++ b/test/include/collection_test.hpp
@@ -330,13 +330,12 @@ namespace collection {
         std::vector<int> dimensions = {100};
 
         for (auto d : dimensions) {
-            std::unique_ptr<HashSourceArgs<MinHash>> args =
-                std::make_unique<HashPoolArgs<MinHash>>(3000);
+            std::unique_ptr<HashSourceArgs<MinHash>> 
+            args = std::make_unique<HashPoolArgs<MinHash>>(3000);
             test_jaccard_search(500, d, std::move(args));
 
             args = std::make_unique<IndependentHashArgs<MinHash>>();
             test_jaccard_search(500, d, std::move(args));
-
 
             args = std::make_unique<TensoredHashArgs<MinHash>>();
             test_jaccard_search(500, d, std::move(args));

--- a/test/include/hash_source_test.hpp
+++ b/test/include/hash_source_test.hpp
@@ -43,8 +43,8 @@ namespace hash_source {
         REQUIRE(hashes.size() == num_tables);
 
         for (size_t rep = 0; rep < num_tables; rep++) {
-            auto hash1 = expected[0];
-            auto hash2 = hashes[0];
+            auto hash1 = expected[rep];
+            auto hash2 = hashes[rep];
             REQUIRE(hash1 == hash2);
         }
     }
@@ -130,6 +130,30 @@ namespace hash_source {
             num_bits
         );
         test_new_api<FHTCrossPolytopeHash, IndependentHashSource<FHTCrossPolytopeHash>>(dimensions, cp_source, num_tables);
+    }
+
+    TEST_CASE("TensoredHashSource new api") {
+        Dataset<UnitVectorFormat> dataset(100);
+        auto dimensions = dataset.get_description();
+
+        size_t num_tables = 50;
+        size_t num_bits = MAX_HASHBITS;
+
+        TensoredHashSource<SimHash> simhash_source(
+            dimensions,
+            SimHashArgs(),
+            num_tables,
+            num_bits
+        );
+        test_new_api<SimHash, TensoredHashSource<SimHash>>(dimensions, simhash_source, num_tables);
+
+        TensoredHashSource<FHTCrossPolytopeHash> cp_source(
+            dimensions,
+            FHTCrossPolytopeArgs(),
+            num_tables,
+            num_bits
+        );
+        test_new_api<FHTCrossPolytopeHash, TensoredHashSource<FHTCrossPolytopeHash>>(dimensions, cp_source, num_tables);
     }
 
     TEST_CASE("TensoredHash reset") {

--- a/test/include/hash_source_test.hpp
+++ b/test/include/hash_source_test.hpp
@@ -91,10 +91,10 @@ namespace hash_source {
         auto dimensions = dataset.get_description();
         test_reset<SimHash>(
             dimensions,
-            HashPoolArgs<SimHash>(50).build(dimensions, 0, 24));
+            HashPoolArgs<SimHash>(50).build(dimensions, 1, 24));
         test_reset<FHTCrossPolytopeHash>(
             dimensions,
-            HashPoolArgs<FHTCrossPolytopeHash>(80).build(dimensions, 0, 20));
+            HashPoolArgs<FHTCrossPolytopeHash>(80).build(dimensions, 1, 20));
     }
 
     TEST_CASE("IndependentSource reset") {
@@ -154,6 +154,33 @@ namespace hash_source {
             num_bits
         );
         test_new_api<FHTCrossPolytopeHash, TensoredHashSource<FHTCrossPolytopeHash>>(dimensions, cp_source, num_tables);
+    }
+
+    TEST_CASE("HashPool new api") {
+        Dataset<UnitVectorFormat> dataset(100);
+        auto dimensions = dataset.get_description();
+
+        size_t pool_size = 3000;
+        size_t num_tables = 2;
+        size_t num_bits = MAX_HASHBITS;
+
+        HashPool<SimHash> simhash_source(
+            dimensions,
+            SimHashArgs(),
+            pool_size,
+            num_tables,
+            num_bits
+        );
+        test_new_api<SimHash, HashPool<SimHash>>(dimensions, simhash_source, num_tables);
+
+        HashPool<FHTCrossPolytopeHash> cp_source(
+            dimensions,
+            FHTCrossPolytopeArgs(),
+            pool_size,
+            num_tables,
+            num_bits
+        );
+        test_new_api<FHTCrossPolytopeHash, HashPool<FHTCrossPolytopeHash>>(dimensions, cp_source, num_tables);
     }
 
     TEST_CASE("TensoredHash reset") {

--- a/test/include/hash_source_test.hpp
+++ b/test/include/hash_source_test.hpp
@@ -196,17 +196,17 @@ namespace hash_source {
 
     TEST_CASE("HashPool hashes") {
         const unsigned int HASH_LENGTH = 24;
-        unsigned int samples = 100;
+        unsigned int samples = 2900;
         Dataset<UnitVectorFormat> dataset(100);
         auto dimensions = dataset.get_description();
         test_hashes<SimHash>(
             dimensions,
-            HashPoolArgs<SimHash>(60).build(dimensions, samples, HASH_LENGTH),
+            HashPoolArgs<SimHash>(3000).build(dimensions, samples, HASH_LENGTH),
             samples,
             HASH_LENGTH);
         test_hashes<FHTCrossPolytopeHash>(
             dimensions,
-            HashPoolArgs<FHTCrossPolytopeHash>(60).build(dimensions, samples, HASH_LENGTH),
+            HashPoolArgs<FHTCrossPolytopeHash>(3000).build(dimensions, samples, HASH_LENGTH),
             samples,
             HASH_LENGTH);
     }


### PR DESCRIPTION
Work in this pull request aims at simplifying the interface to hash sources and hash functions.

## Previous situation

Previously, in PUFFINN we had the following architecture:

 - `HashFunction` classes (e.g. `SimHash`): provide hash bits, which are organized in
 - `HashCollection` classes: provide all the repetitions using HashFunction classes and combining their bits. They may precompute hashes (like `TensoredHashSource`) and then combine these pre-computed things on the fly
 - There are classes inheriting fom `HashSourceState` that carry around either the hash bits for a vector or a vector itself. This is done to provide a uniform interface for both the collections that pre-compute hashes (e.g. TensoredHashSource) and collections that compute hash values on the fly (e.g. IndependentHashSource)
 - The repetition number is implicit

This design can be improved in the following respects:
 - it is based on mutable HashSourceState objects, making it harder to parallelize
 - it allocates a lot of small(ish) objects on the heap, an operation that is rather expensive. In particular, for pooled and tensored hash collections it allocates a vector containing all the hash values to mix and match in the state object
 - it makes a lot of virtual calls, because all functionality is provided by means of virtual classes, and has a lot of indirection, since most of the components are wrapped in smart pointers

## Improvements

The main improvement is replacing the pipeline `HashSource->reset()` + `HashFunction(HashState)` with a single call to `HashSource::hash_repetitions`. This function (for which we have an implementation for each of the three hash collections) takes two parameters: the input vector to hash and a vector that will store the output hash values, one for each table in the index:

        void hash_repetitions(
            typename T::Sim::Format::Type * input,
            std::vector<LshDatatype> & output
        ) {
           // Implementation here, depending on the hash collection
        }

This design allows to reuse the allocation for the output for other points. Furthermore, it completely removes the mutable state that has to be passed around.

At present (3c2046f171a7a525ea7c3f8ad8606d2ef8d0deaf), `Index` is using `hash_repetitions` instead of the stateful pipeline. All tests pass, the change is completely transparent to users of `Index` (but not to users of `PrefixMap`).

## Some preliminary results

Running the following command

    build/GloveJoin glove.twitter.27B.25d.txt 100 0.9 LSHJoinGlobal 524288000

on this branch takes about 25 seconds to build the index. On the `master` branch (d8eac942ef76d184bb648fdcc2730303f9eb859c), the same command takes 7 second to run.

So we should investigate why this is slower.

## Other changes

`PrefixMap` is no longer responsible for hashing the values that it refers to. Rather, we now just insert hash values computed elsewhere (i.e. in `Index::rebuild`). This makes for a much simpler design (in my opinion).

## Next steps

I would like to try to get rid of virtual class altogether, by using templates.
