### PR TITLE
Parallel implementation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,9 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17 -Wall -Wextra -Wno-noexcept-t
 find_package(OpenMP)
 if (OpenMP_FOUND)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
-    include_directories("${OpenMP_CXX_INCLUDE_DIR}")
+    if (OpenMP_CXX_INCLUDE_DIR)
+        include_directories("${OpenMP_CXX_INCLUDE_DIR}")
+    endif()
 endif()
 
 find_package(HDF5)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17 -Wall -Wextra -Wno-noexcept-t
 find_package(OpenMP)
 if (OpenMP_FOUND)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
+    include_directories("${OpenMP_CXX_INCLUDE_DIR}")
 endif()
 
 find_package(HDF5)

--- a/bench/bench.cpp
+++ b/bench/bench.cpp
@@ -14,6 +14,7 @@
 #include <sstream>
 #include <iostream>
 #include <chrono>
+#include <omp.h>
 
 const unsigned int MB = 1024*1024;
 
@@ -75,24 +76,41 @@ void bench_index_build(const std::vector<std::vector<float>> & dataset) {
     // To benchmark the index build time we have to start from a new
     // index at each measurement iteration, otherwise the index is already populated
     // and no rebuild is triggered.
-    auto bencher = ankerl::nanobench::Bench()
-        .title("Index building");
-    auto index_memory = 100*MB;
-    // auto index_memory = 0.8*MB;
-
-    bencher.run("index_insert_data", [&] {
-        puffinn::Index<puffinn::CosineSimilarity, puffinn::SimHash> index(
-            dimensions,
-            index_memory
-        );
-        for (auto v : dataset) { index.insert(v); }
-    });
+    auto bencher = ankerl::nanobench::Bench();
+    // auto index_memory = 100*MB;
     
     // memory is set so that we have 600 tables
-    do_build_index<puffinn::SimHash, puffinn::IndependentHashArgs<puffinn::SimHash>>(&bencher, "SimHash independent", dataset, 537*MB); // 74 MB
-    do_build_index<puffinn::SimHash, puffinn::TensoredHashArgs<puffinn::SimHash>>(&bencher, "SimHash tensored", dataset, 534*MB); // 70.6 MB
-    do_build_index<puffinn::FHTCrossPolytopeHash, puffinn::IndependentHashArgs<puffinn::FHTCrossPolytopeHash>>(&bencher, "FHT CrossPolytope independent", dataset, 534.5*MB); // 71.2 MB
-    do_build_index<puffinn::FHTCrossPolytopeHash, puffinn::TensoredHashArgs<puffinn::FHTCrossPolytopeHash>>(&bencher, "FHT CrossPolytope tensored", dataset, 534*MB); // 70.5 MB
+    bencher.title("Simhash independent");
+    omp_set_num_threads(1);
+    do_build_index<puffinn::SimHash, puffinn::IndependentHashArgs<puffinn::SimHash>>(&bencher, "1 thread", dataset, 537*MB); // 74 MB
+    omp_set_num_threads(2);
+    do_build_index<puffinn::SimHash, puffinn::IndependentHashArgs<puffinn::SimHash>>(&bencher, "2 threads", dataset, 537*MB); // 74 MB
+    omp_set_num_threads(4);
+    do_build_index<puffinn::SimHash, puffinn::IndependentHashArgs<puffinn::SimHash>>(&bencher, "4 threads", dataset, 537*MB); // 74 MB
+    omp_set_num_threads(8);
+    do_build_index<puffinn::SimHash, puffinn::IndependentHashArgs<puffinn::SimHash>>(&bencher, "8 threads", dataset, 537*MB); // 74 MB
+    omp_set_num_threads(16);
+    do_build_index<puffinn::SimHash, puffinn::IndependentHashArgs<puffinn::SimHash>>(&bencher, "16 threads", dataset, 537*MB); // 74 MB
+    omp_set_num_threads(32);
+    do_build_index<puffinn::SimHash, puffinn::IndependentHashArgs<puffinn::SimHash>>(&bencher, "32 threads", dataset, 537*MB); // 74 MB
+
+    bencher.title("Simhash tensored");
+    omp_set_num_threads(1);
+    do_build_index<puffinn::SimHash, puffinn::TensoredHashArgs<puffinn::SimHash>>(&bencher, "1 thread", dataset, 537*MB); // 74 MB
+    omp_set_num_threads(2);
+    do_build_index<puffinn::SimHash, puffinn::TensoredHashArgs<puffinn::SimHash>>(&bencher, "2 threads", dataset, 537*MB); // 74 MB
+    omp_set_num_threads(4);
+    do_build_index<puffinn::SimHash, puffinn::TensoredHashArgs<puffinn::SimHash>>(&bencher, "4 threads", dataset, 537*MB); // 74 MB
+    omp_set_num_threads(8);
+    do_build_index<puffinn::SimHash, puffinn::TensoredHashArgs<puffinn::SimHash>>(&bencher, "8 threads", dataset, 537*MB); // 74 MB
+    omp_set_num_threads(16);
+    do_build_index<puffinn::SimHash, puffinn::TensoredHashArgs<puffinn::SimHash>>(&bencher, "16 threads", dataset, 537*MB); // 74 MB
+    omp_set_num_threads(32);
+    do_build_index<puffinn::SimHash, puffinn::TensoredHashArgs<puffinn::SimHash>>(&bencher, "32 threads", dataset, 537*MB); // 74 MB
+
+    // do_build_index<puffinn::SimHash, puffinn::TensoredHashArgs<puffinn::SimHash>>(&bencher, "SimHash tensored", dataset, 534*MB); // 70.6 MB
+    // do_build_index<puffinn::FHTCrossPolytopeHash, puffinn::IndependentHashArgs<puffinn::FHTCrossPolytopeHash>>(&bencher, "FHT CrossPolytope independent", dataset, 534.5*MB); // 71.2 MB
+    // do_build_index<puffinn::FHTCrossPolytopeHash, puffinn::TensoredHashArgs<puffinn::FHTCrossPolytopeHash>>(&bencher, "FHT CrossPolytope tensored", dataset, 534*MB); // 70.5 MB
 }
 
 void bench_query(const std::vector<std::vector<float>> & dataset) {

--- a/bench/bench.cpp
+++ b/bench/bench.cpp
@@ -65,7 +65,7 @@ void do_build_index(ankerl::nanobench::Bench * bencher, const char * name, const
             THashSourceArgs()
         );
         for (auto v : dataset) { index.insert(v); }
-        index.rebuild();
+        index.rebuild(false);
     });
 }
 

--- a/bench/bench.cpp
+++ b/bench/bench.cpp
@@ -198,9 +198,9 @@ int main(int argc, char ** argv) {
     }
     auto dataset = read_glove(argv[1]);
 
-    bench_api_simhash(dataset);
+    // bench_api_simhash(dataset);
     // bench_query(dataset);
-    // bench_index_build(dataset);
+    bench_index_build(dataset);
     // bench_hash(dataset);
 }
 

--- a/include/puffinn/collection.hpp
+++ b/include/puffinn/collection.hpp
@@ -10,6 +10,7 @@
 #include "puffinn/prefixmap.hpp"
 #include "puffinn/typedefs.hpp"
 
+#include "omp.h"
 #include <cassert>
 #include <istream>
 #include <iostream>
@@ -274,7 +275,6 @@ namespace puffinn {
                 num_tables = 1000;
             }
 
-            auto start = std::chrono::steady_clock::now();
             // if rebuild has been called before
             if (hash_source) {
                 // Resize the number of tables

--- a/include/puffinn/collection.hpp
+++ b/include/puffinn/collection.hpp
@@ -302,8 +302,12 @@ namespace puffinn {
             g_performance_metrics.start_timer(Computation::IndexHashing);
             // Compute hashes for the new vectors in order, so that caching works.
             // Hash a vector in all the different ways needed.
-            std::vector<LshDatatype> hash_values;
+            std::vector<std::vector<LshDatatype>> tl_hash_values;
+            tl_hash_values.resize(omp_get_max_threads());
+            #pragma omp parallel for
             for (size_t idx=last_rebuild; idx < dataset.get_size(); idx++) {
+                auto tid = omp_get_thread_num();
+                auto & hash_values = tl_hash_values[tid];
                 // Write the hash values in the vector
                 this->hash_source->hash_repetitions(dataset[idx], hash_values);
                 // Copy the hash values in the appropriate prefix maps

--- a/include/puffinn/hash_source/independent.hpp
+++ b/include/puffinn/hash_source/independent.hpp
@@ -86,7 +86,7 @@ namespace puffinn {
             typename T::Sim::Format::Type * input,
             std::vector<LshDatatype> & output
         ) const {
-            output.clear();
+            output.resize(num_hashers);
             // Iterate through all the functions, accumulating bits
             for (size_t rep = 0; rep < num_hashers; rep++) {
                 size_t offset = rep * functions_per_hasher;
@@ -96,7 +96,7 @@ namespace puffinn {
                     res |= hash_functions[offset+i](input);
                 }
                 res >>= bits_to_cut;
-                output.push_back(res);
+                output[rep] = res;
             }
         }
 

--- a/include/puffinn/prefixmap.hpp
+++ b/include/puffinn/prefixmap.hpp
@@ -6,6 +6,7 @@
 #include "puffinn/performance.hpp"
 #include "puffinn/sorthash.hpp"
 
+#include "omp.h"
 #include <algorithm>
 #include <cstdint>
 #include <functional>
@@ -73,7 +74,8 @@ namespace puffinn {
         std::vector<uint32_t> indices;
         std::vector<LshDatatype> hashes;
         // Scratch space for use when rebuilding. The length and capacity is set to 0 otherwise.
-        std::vector<HashedVecIdx> rebuilding_data;
+        // std::vector<HashedVecIdx> rebuilding_data;
+        std::vector<std::vector<HashedVecIdx>> parallel_rebuilding_data;
 
         // Length of the hash values used.
         unsigned int hash_length;
@@ -90,6 +92,8 @@ namespace puffinn {
         {
             // Ensure that the map can be queried even if nothing is inserted.
             rebuild();
+            auto max_threads = omp_get_max_threads();
+            parallel_rebuilding_data.resize(max_threads);
         }
 
         PrefixMap(std::istream& in, HashSource<T>& source) {
@@ -102,13 +106,16 @@ namespace puffinn {
                 in.read(reinterpret_cast<char*>(&hashes[0]), len*sizeof(LshDatatype));
             }
 
+            // TODO Handle serialization
             size_t rebuilding_len;
             in.read(reinterpret_cast<char*>(&rebuilding_len), sizeof(size_t));
-            rebuilding_data.resize(rebuilding_len);
+            // rebuilding_data.resize(rebuilding_len);
             if (rebuilding_len != 0) {
-                in.read(
-                    reinterpret_cast<char*>(&rebuilding_data[0]), 
-                    rebuilding_len*sizeof(HashedVecIdx));
+                for (size_t i=0; i<rebuilding_len; i++) {
+                    HashedVecIdx v;
+                    in.read(reinterpret_cast<char*>(&v), sizeof(HashedVecIdx));
+                    parallel_rebuilding_data[0].push_back(v);
+                }
             }
 
             in.read(reinterpret_cast<char*>(&hash_length), sizeof(unsigned int));
@@ -126,12 +133,17 @@ namespace puffinn {
                 out.write(reinterpret_cast<const char*>(&hashes[0]), len*sizeof(LshDatatype));
             }
 
-            size_t rebuilding_len = rebuilding_data.size();
+            size_t rebuilding_len = 0;
+            for (auto & rd : parallel_rebuilding_data) {
+                rebuilding_len += rd.size();
+            }
             out.write(reinterpret_cast<const char*>(&rebuilding_len), sizeof(size_t));
             if (rebuilding_len != 0) {
-                out.write(
-                    reinterpret_cast<const char*>(&rebuilding_data[0]),
-                    rebuilding_len*sizeof(HashedVecIdx));
+                for (auto & rd : parallel_rebuilding_data) {
+                    for (size_t i = 0; i <rd.size(); i++) {
+                        out.write(reinterpret_cast<const char*>(&rd[i]), sizeof(HashedVecIdx));
+                    }
+                }
             }
 
             out.write(reinterpret_cast<const char*>(&hash_length), sizeof(unsigned int));
@@ -143,16 +155,18 @@ namespace puffinn {
 
         // Add a hash value, and associated index, to be included next time rebuild is called. 
         void insert(uint32_t idx, LshDatatype hash_value) {
-            rebuilding_data.push_back({ idx, hash_value });
+            auto tid = omp_get_thread_num();
+            parallel_rebuilding_data[tid].push_back({ idx, hash_value });
         }
 
         // Reserve the correct amount of memory before inserting.
         void reserve(size_t size) {
-            if (hashes.size() == 0) {
-                rebuilding_data.reserve(size);
-            } else {
-                rebuilding_data.reserve(size-(hashes.size()-2*SEGMENT_SIZE));
-            }
+            // TODO Divide equally across the vectors
+            // if (hashes.size() == 0) {
+            //     rebuilding_data.reserve(size);
+            // } else {
+            //     rebuilding_data.reserve(size-(hashes.size()-2*SEGMENT_SIZE));
+            // }
         }
 
         void rebuild() {
@@ -165,10 +179,11 @@ namespace puffinn {
             std::vector<uint32_t> tmp_indices;
             std::vector<LshDatatype> out_hashes;
             std::vector<uint32_t> out_indices;
-            tmp_hashes.reserve(hashes.size() + rebuilding_data.size());
-            tmp_indices.reserve(hashes.size() + rebuilding_data.size());
-            out_hashes.reserve(hashes.size() + rebuilding_data.size());
-            out_indices.reserve(hashes.size() + rebuilding_data.size());
+            // TODO Reserve the right output of space
+            // tmp_hashes.reserve(hashes.size() + rebuilding_data.size());
+            // tmp_indices.reserve(hashes.size() + rebuilding_data.size());
+            // out_hashes.reserve(hashes.size() + rebuilding_data.size());
+            // out_indices.reserve(hashes.size() + rebuilding_data.size());
 
             if (hashes.size() != 0) {
                 // Move data to temporary vector for sorting.
@@ -177,9 +192,11 @@ namespace puffinn {
                     tmp_indices.push_back(indices[i]);
                 }
             }
-            for (auto pair : rebuilding_data) {
-                tmp_indices.push_back(pair.first);
-                tmp_hashes.push_back(pair.second);
+            for (auto & rebuilding_data : parallel_rebuilding_data) {
+                for (auto pair : rebuilding_data) {
+                    tmp_indices.push_back(pair.first);
+                    tmp_hashes.push_back(pair.second);
+                }
             }
             
             g_performance_metrics.start_timer(Computation::Sorting);
@@ -210,22 +227,29 @@ namespace puffinn {
                 indices.push_back(0);
             }
 
+            size_t rebuilding_data_size = 0;
+            for (auto & rd : parallel_rebuilding_data) {
+                rebuilding_data_size += rd.size();
+            }
+
             // Build prefix_index data structure.
             // Index of the first occurence of the prefix
             uint32_t idx = 0;
             for (unsigned int prefix=0; prefix < (1u << PREFIX_INDEX_BITS); prefix++) {
                 while (
-                    idx < rebuilding_data.size() &&
+                    idx < rebuilding_data_size &&
                     (hashes[SEGMENT_SIZE+idx] >> (hash_length-PREFIX_INDEX_BITS)) < prefix
                 ) {
                     idx++;
                 }
                 prefix_index[prefix] = SEGMENT_SIZE+idx;
             }
-            prefix_index[1 << PREFIX_INDEX_BITS] = SEGMENT_SIZE+rebuilding_data.size();
+            prefix_index[1 << PREFIX_INDEX_BITS] = SEGMENT_SIZE+rebuilding_data_size;
 
-            rebuilding_data.clear();
-            rebuilding_data.shrink_to_fit();
+            for (auto & rd : parallel_rebuilding_data) {
+                rd.clear();
+                rd.shrink_to_fit();
+            }
 
             g_performance_metrics.store_time(Computation::Rebuilding);
         }

--- a/join-experiments/glove-join.cpp
+++ b/join-experiments/glove-join.cpp
@@ -101,8 +101,8 @@ int main(int argc, char* argv[]) {
     puffinn::Index<puffinn::CosineSimilarity, puffinn::SimHash> index(
         dimensions,
         space_usage,
-        puffinn::TensoredHashArgs<puffinn::SimHash>()
-        // puffinn::IndependentHashArgs<puffinn::SimHash>()
+        // puffinn::TensoredHashArgs<puffinn::SimHash>()
+        puffinn::IndependentHashArgs<puffinn::SimHash>()
     );
     // Insert each vector into the index.
     for (auto word : dataset.words) { index.insert(dataset.vectors[word]); }


### PR DESCRIPTION
Make index construction parallel over the input vectors.

## Index building on 10k elements

Times are taken on a Linux machine with 32 cores

This branch:

|               ns/op |                op/s |    err% |          ins/op |          cyc/op |    IPC |         bra/op |   miss% |     total | Index building
|--------------------:|--------------------:|--------:|----------------:|----------------:|-------:|---------------:|--------:|----------:|:---------------
|      591,840,888.00 |                1.69 |    5.4% |2,323,297,234.00 |1,414,605,472.00 |  1.642 | 418,529,241.00 |    1.2% |      6.67 | :wavy_dash: `SimHash independent` (Unstable with ~1.0 iters. Increase `minEpochIterations` to e.g. 10)
|      338,977,558.00 |                2.95 |    1.1% |1,527,795,601.00 |  809,769,824.00 |  1.887 | 254,359,912.00 |    1.8% |      3.78 | `SimHash tensored`
|    1,733,791,836.00 |                0.58 |    0.6% |7,951,577,286.00 |5,041,947,648.00 |  1.577 |1,064,973,532.00 |    2.1% |     19.20 | `FHT CrossPolytope independent`
|    1,215,016,033.00 |                0.82 |    2.1% |5,828,819,938.00 |3,543,257,920.00 |  1.645 | 745,181,398.00 |    1.6% |     13.38 | `FHT CrossPolytope tensored`

On master

|               ns/op |                op/s |    err% |          ins/op |          cyc/op |    IPC |         bra/op |   miss% |     total | Index building
|--------------------:|--------------------:|--------:|----------------:|----------------:|-------:|---------------:|--------:|----------:|:---------------
|      542,685,104.00 |                1.84 |   12.3% |2,484,465,411.00 |1,635,970,656.00 |  1.519 | 453,069,954.00 |    1.1% |      6.89 | :wavy_dash: `SimHash independent` (Unstable with ~1.0 iters. Increase `minEpochIterations` to e.g. 10)
|    1,298,192,274.00 |                0.77 |   14.3% |2,230,277,140.00 |4,035,548,896.00 |  0.553 | 427,102,793.00 |    1.0% |     14.82 | :wavy_dash: `SimHash tensored` (Unstable with ~1.0 iters. Increase `minEpochIterations` to e.g. 10)
|    2,146,318,181.00 |                0.47 |    8.7% |8,266,382,067.00 |6,662,144,704.00 |  1.241 |1,142,797,494.00 |    1.8% |     24.90 | :wavy_dash: `FHT CrossPolytope independent` (Unstable with ~1.0 iters. Increase `minEpochIterations` to e.g. 10)
|    2,240,502,384.00 |                0.45 |    4.1% |6,287,495,186.00 |7,033,052,768.00 |  0.894 | 849,652,083.00 |    1.4% |     25.02 | `FHT CrossPolytope tensored`